### PR TITLE
fix: add `via MM` to webhook title

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import TelegramBot from 'node-telegram-bot-api';
 import {config} from './config';
 import {
   constructDiscordMessageFromTelegramMessage,
+  getWebhookUsernameFromUsername,
   postToDiscord,
   publishTelegramMessageToPubSub,
 } from './lib';
@@ -56,7 +57,10 @@ app.post('/telegram-subscription', async (req, res) => {
       discordPromises.push(
         new Promise((resolve, reject) => {
           const form = new FormData();
-          form.append('username', `${msg.from?.username} (Meeple Market)`);
+          form.append(
+            'username',
+            getWebhookUsernameFromUsername(msg.from?.username as string)
+          );
 
           let content;
           // This is a reply message

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -29,7 +29,7 @@ export const constructDiscordMessageFromTelegramMessage = (
   }
 
   const webhookResponse: DiscordWebhookResponse = {
-    username: msg.from?.username as string,
+    username: getWebhookUsernameFromUsername(msg.from?.username as string),
     content: content,
   };
 
@@ -46,4 +46,8 @@ export const publishTelegramMessageToPubSub = (msg: TelegramBot.Message) => {
   return pubSubClient
     .topic(config.google.interaction_topic, {enableMessageOrdering: true})
     .publishMessage(message);
+};
+
+export const getWebhookUsernameFromUsername = (username: string) => {
+  return `${username} (via Meeple Market)`;
 };


### PR DESCRIPTION
Adds `(via Meeple Market)` to as the webhook bot title.